### PR TITLE
Add nested reference note

### DIFF
--- a/pages/tokens/aliases.en.mdx
+++ b/pages/tokens/aliases.en.mdx
@@ -27,3 +27,5 @@ import ReactPlayer from 'react-player'
   url="/alias-recording.mp4"
 />
 
+## Nested references
+We also support nested references in the form of `{colors.{primary}.500}` up to 1 level of depth, any further level of depth is not supported. This is not supported by any other tool and is also not part of the DTCG format, in addition it can negatively impact performance of token resolution.


### PR DESCRIPTION
This pull request adds a new section to the `aliases.en.mdx` file in the `pages/tokens` directory explaining the tool's support for nested references up to 1 level of depth.

* <a href="diffhunk://#diff-30ab029fcc3314018e828d861e7a4f581f8df54287ac3bc0a4213092e97aa51aR30-R31">`pages/tokens/aliases.en.mdx`</a>: Added a new section titled "Nested references" explaining the tool's support for nested references up to 1 level of depth and noting that this feature is not supported by any other tool and can negatively impact performance.