### PR TITLE
Edit text and add callout

### DIFF
--- a/pages/tokens/json-schema.en.mdx
+++ b/pages/tokens/json-schema.en.mdx
@@ -193,7 +193,7 @@ If you're using multi-file sync (a Pro feature), your token files will not have 
 ## Allowed token values
 
 <Callout type="warning" emoji="⚠️">
-  It is suggested against using `Value` or `Type` as parts of token naming as it will create conflict in the JSON. Both the aforementioned are by default a part of the JSON script
+  It is suggested against using `Value` or `Type` as parts of token naming as it will create conflict in the JSON. Both the aforementioned are by default a part of the JSON script.
 </Callout>
 
 Depending on the `Type` of a token, we allow different values. The following JSON is a simplified visualisation:

--- a/pages/tokens/json-schema.en.mdx
+++ b/pages/tokens/json-schema.en.mdx
@@ -190,7 +190,7 @@ If you're using multi-file sync (a Pro feature), your token files will not have 
 
 ## Allowed token values
 
-<Callout emoji="⚠️">
+<Callout type="warning" emoji="⚠️">
   It is suggested against using `Value` or `Type` as parts of token naming as it will create conflict in the JSON. Both the aforementioned are by default a part of the JSON script
 </Callout>
 

--- a/pages/tokens/json-schema.en.mdx
+++ b/pages/tokens/json-schema.en.mdx
@@ -190,7 +190,11 @@ If you're using multi-file sync (a Pro feature), your token files will not have 
 
 ## Allowed token values
 
-Depending on the type of a token we allow different values, this following JSON is trying to visualize that:
+<Callout emoji="⚠️">
+  It is suggested against using `Value` or `Type` as parts of token naming as it will create conflict in the JSON. Both the aforementioned are by default a part of the JSON script
+</Callout>
+
+Depending on the `Type` of a token, we allow different values. The following JSON is a simplified visualisation:
 
 ```
 {

--- a/pages/tokens/json-schema.en.mdx
+++ b/pages/tokens/json-schema.en.mdx
@@ -1,5 +1,7 @@
 # JSON Schema
 
+import Callout from 'nextra-theme-docs/callout'
+
 Tokens are represented in JSON, as a list of objects. A valid JSON would look like this:
 
 ```


### PR DESCRIPTION
Added callout mentioning to avoid using `value` and `type` as part of token naming as we've seen users face issues when using them.