### PR TITLE
docs: fix typo - update border-radius-tokens.en.mdx

### DIFF
--- a/pages/available-tokens/border-radius-tokens.en.mdx
+++ b/pages/available-tokens/border-radius-tokens.en.mdx
@@ -1,6 +1,6 @@
 # Border Radius Tokens
 
-Radius tokens give you the possibility to define values for your border radius. You can either create a single value token or define multiple border radii in a token.
+Radius tokens give you the possibility to define values for your border radius. You can either create a single value token or define multiple border radius in a token.
 
 #### How to use
 Create a Border radius token under the `Border radius` category by clicking on the `+` icon.  


### PR DESCRIPTION
Correction of a typing error on the **border-radius-tokens.en.mdx** page.

~~border radii~~ => **border radius**