### PR TITLE
Add missing link to sync-provider-overview.en.mdx

### DIFF
--- a/pages/token-storage-and-sync/sync-provider-overview.en.mdx
+++ b/pages/token-storage-and-sync/sync-provider-overview.en.mdx
@@ -82,7 +82,7 @@ Once you have an active **sync provider**, you can find the **sync actions** at 
 	- [→ Jump to the Branch Switching guide](/token-storage-and-sync/sync-branch-pro)
 - The **Token format** displays the format of your current branch, either W3C DTCG or Legacy, which influences how your Token JSON files are written. 
 	- Select the button to **switch Token formats**. 
-	-  → Learn more about the W3C DTCG Token Format #add-doc-link/token-format 
+	-  [→ Learn more about the W3C DTCG Token Format](/token-format/token-format-view-change-dtcg)
 - The **pull button** will have an indicator appear when new Token data can be received from your sync provider.
 	- Select the button to open the **pull modal**.
 - The **push button** will have an indicator appear when changes to your Tokens can be sent to your sync provider.


### PR DESCRIPTION
This PR simply adds the missing link for https://docs.tokens.studio/token-format/token-format-view-change-dtcg that was referenced to be added but was not in place.