### PR TITLE
Fix Github classic token instructions typo

### DIFF
--- a/pages/token-storage-and-sync/sync-provider-github.en.mdx
+++ b/pages/token-storage-and-sync/sync-provider-github.en.mdx
@@ -60,7 +60,7 @@ Log into you GitHub account:
 		- Less specific, one PAT provides access to multiple repositories.
 
 #### Generate a new classic access token
-- Select **Generate new token (beta)**
+- Select **Generate new token (classic)**
 - Add a **Note** of what the token is for. 
 	- Example: `test-token repo sync to tokens studio`
 - Select an **Expiration** time frame 


### PR DESCRIPTION
Fixes typo on GitHub sync instructions on how to create a classic personal access token.